### PR TITLE
Feedback excluded paths should contain wildcard for admin paths

### DIFF
--- a/os2web_node_feedback.strongarm.inc
+++ b/os2web_node_feedback.strongarm.inc
@@ -14,7 +14,7 @@ function os2web_node_feedback_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'feedback_excluded_paths';
-  $strongarm->value = 'admin/
+  $strongarm->value = 'admin/*
 admin/reports/feedback
 <front>';
   $export['feedback_excluded_paths'] = $strongarm;


### PR DESCRIPTION
Excluded paths doesn't work correctly for admin paths. This caused by missing wildcard in default strongarm value of "feedback_excluded_paths".
